### PR TITLE
[video_player_web] Error: Unsupported operation: Infinity.

### DIFF
--- a/packages/video_player/video_player_web/lib/video_player_web.dart
+++ b/packages/video_player/video_player_web/lib/video_player_web.dart
@@ -258,7 +258,7 @@ class _VideoPlayer {
       VideoEvent(
         eventType: VideoEventType.initialized,
         duration: Duration(
-          milliseconds: (videoElement.duration * 1000).round(),
+          milliseconds: ((videoElement.duration == double.infinity ? 1 : videoElement.duration) * 1000).round(),
         ),
         size: Size(
           videoElement.videoWidth.toDouble() ?? 0.0,


### PR DESCRIPTION
(This happens because of a chromium bug https://bugs.chromium.org/p/chromium/issues/detail?id=656426)

```Error: Unsupported operation: Infinity
    at Object.throw_ [as throw] (http://localhost:37461/dart_sdk.js:4328:11)
    at Number.[dartx.round] (http://localhost:37461/dart_sdk.js:15560:17)
    at video_player_web._VideoPlayer.new.sendInitialized (http://localhost:37461/packages/video_player_web/video_player_web.dart.lib.js:300:259)
    at http://localhost:37461/packages/video_player_web/video_player_web.dart.lib.js:254:16
    at Object._checkAndCall (http://localhost:37461/dart_sdk.js:4538:16)
    at Object.dcall (http://localhost:37461/dart_sdk.js:4543:17)
    at HTMLVideoElement.<anonymous> (http://localhost:37461/dart_sdk.js:105045:21)
```

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
